### PR TITLE
Character timetravel is hard

### DIFF
--- a/scenes/Character.tscn
+++ b/scenes/Character.tscn
@@ -8,7 +8,7 @@
 custom_solver_bias = 0.0
 radius = 15.293
 
-[node name="Character" type="KinematicBody2D"]
+[node name="Character" type="KinematicBody2D" index="0"]
 
 input_pickable = false
 collision_layer = 1

--- a/scenes/CollisionTest.tscn
+++ b/scenes/CollisionTest.tscn
@@ -8,7 +8,7 @@
 [ext_resource path="res://scenes/HUD.tscn" type="PackedScene" id=6]
 [ext_resource path="res://scenes/Keycard.tscn" type="PackedScene" id=7]
 
-[node name="Node2D" type="Node2D" index="0"]
+[node name="Node2D" type="Node2D"]
 
 script = ExtResource( 1 )
 

--- a/scenes/CollisionTest.tscn
+++ b/scenes/CollisionTest.tscn
@@ -8,7 +8,7 @@
 [ext_resource path="res://scenes/HUD.tscn" type="PackedScene" id=6]
 [ext_resource path="res://scenes/Keycard.tscn" type="PackedScene" id=7]
 
-[node name="Node2D" type="Node2D"]
+[node name="Node2D" type="Node2D" index="0"]
 
 script = ExtResource( 1 )
 

--- a/scenes/Keycard.tscn
+++ b/scenes/Keycard.tscn
@@ -1,7 +1,8 @@
 [gd_scene load_steps=3 format=2]
 
-[ext_resource path="res://scripts/KeycardD.gd" type="Script" id=1]
+[ext_resource path="res://scripts/Keycard.gd" type="Script" id=1]
 [ext_resource path="res://assets/sprite_keycard.png" type="Texture" id=2]
+
 
 [node name="Keycard" type="Area2D"]
 

--- a/scripts/Character.gd
+++ b/scripts/Character.gd
@@ -40,7 +40,7 @@ func _physics_process(delta):
 		#update position AFTER storing the event (if necessary)
 		position += velocity
 	elif self.state == 'replay':
-		if replay_index > len(event_list):
+		if replay_index >= len(event_list):
 			return
 		var event = event_list[replay_index]
 		if event[0] == 'motion':
@@ -73,6 +73,10 @@ func _physics_process(delta):
 			replay_index += 1
 			self.show()
 
+func pickup(item):
+	inventory.append(item.card_name)
+	event_list.append(["pickup", global.time, {'position': position, 'item': item.card_name, 'velocity': Vector2(0,0)}])
+
 func reset_to_events(events):
 	if events == null:
 		return
@@ -100,3 +104,10 @@ func finalize_jump(t):
 		var event = global.find_adjacent_events(t, event_list)[0]
 		if event:
 			replay_index = self.event_list.find(event)+1
+			var cursor = replay_index + 1
+			while cursor < len(event_list):
+				var item_event = event_list[cursor]
+				if item_event[0] == 'pickup':
+					inventory.remove(inventory.find(item_event[2]['item']))
+				else:
+					cursor += 1

--- a/scripts/Keycard.gd
+++ b/scripts/Keycard.gd
@@ -6,10 +6,6 @@ var event_list = []
 export(String) var card_color
 var sprite
 
-# class member variables go here, for example:
-# var a = 2
-# var b = "textvar"
-
 func _ready():
 	self.connect("body_entered", self, "_on_keycard_body_entered", [self])
 	sprite = find_node("Keycard_Sprite")
@@ -19,24 +15,30 @@ func _ready():
 		sprite.modulate = Color(0, 1, 0)
 	elif card_color == "red":
 		sprite.modulate = Color(1, 0, 0)
+	
+	#seed initial event
+	event_list.append(["spawn", 0, {"position": position}])
 
 func _on_keycard_body_entered(body, origin):
-	if body.get_name() == "Character":
+	if sprite.is_visible() && body.get_name() == "Character":
 		origin.pickup(body)
 
 func pickup(body):
-	#TODO check to see if they keycard has already been picked up
 	self.hide()
 	#add keycard to inventory
 	body.inventory.append(self.card_name)
+	event_list.append(["pickup", global.time, {"position": position}])
 	print("Picked up " + self.card_name)
 
 func reset_to_events(events):
 	if events == null:
 		return
 	var early_event = events[0]
-	#var late_event = null
-	#if events[1]:
-	#	late_event = events[1][0]
+	if early_event[0] == "spawn":
+		self.show()
+	if early_event[0] == "pickup":
+		self.hide()
 	print(early_event)
-	
+
+func finalize_jump(t):
+	global.wipe_future(self, t)

--- a/scripts/Keycard.gd
+++ b/scripts/Keycard.gd
@@ -20,15 +20,11 @@ func _ready():
 	event_list.append(["spawn", 0, {"position": position}])
 
 func _on_keycard_body_entered(body, origin):
-	if sprite.is_visible() && body.get_name() == "Character":
-		origin.pickup(body)
-
-func pickup(body):
-	self.hide()
-	#add keycard to inventory
-	body.inventory.append(self.card_name)
-	event_list.append(["pickup", global.time, {"position": position}])
-	print("Picked up " + self.card_name)
+	if self.is_visible() && body.get_name() == "Character":
+		body.pickup(origin)
+		self.hide()
+		event_list.append(["pickup", global.time, {"position": position}])
+		print("Picked up " + self.card_name)
 
 func reset_to_events(events):
 	if events == null:

--- a/scripts/Keycard.gd
+++ b/scripts/Keycard.gd
@@ -20,7 +20,7 @@ func _ready():
 	event_list.append(["spawn", 0, {"position": position}])
 
 func _on_keycard_body_entered(body, origin):
-	if self.is_visible() && body.get_name() == "Character":
+	if self.is_visible() && body.get_filename() == global.CHARACTER_FILEPATH:
 		body.pickup(origin)
 		self.hide()
 		event_list.append(["pickup", global.time, {"position": position}])

--- a/scripts/Pressureplate.gd
+++ b/scripts/Pressureplate.gd
@@ -22,7 +22,7 @@ func _ready():
 	event_list.append([event_type_string, 0, {'state' : is_on()}])
 
 func _on_pressureplate_body_entered(body, origin):
-	if body.get_name() == "Character":
+	if body.get_filename() == global.CHARACTER_FILEPATH:
 		origin.toggle()
 
 func toggle():


### PR DESCRIPTION
# master < character-timetravel-is-hard
12 Dec 2018

 - [X] Added event tracking to the keycard.
 - [X] Fixed hidden entities retaining collision.
 - [X] Redid character time travel to anchor the player and spawn an echo instead of not that.
 - [X] Character inventory now time travels properly.
 - [X] Fixed seeded character event to happen at time 0.
 - [X] Taught character how to replay pickup and drop events.
 # Testing
 - [X] Tested basic time travel
 - [X] Walked through disabled character
 - [X] Echo picked up a keycard
 - [X] Character retained card after time travel
