### PR TITLE
Made only keycard doors close when you player leaves the nearby area.

### DIFF
--- a/scenes/CollisionTest.tscn
+++ b/scenes/CollisionTest.tscn
@@ -50,12 +50,14 @@ plate_name = "time"
 
 position = Vector2( 475.227, 325 )
 SPEED = 15
+DOOR_TYPE = "pressure"
 
 [node name="TimeDoor" parent="." index="7" instance=ExtResource( 4 )]
 
 position = Vector2( -225, 125 )
 rotation = 1.5708
 SPEED = 15
+DOOR_TYPE = "pressure"
 
 [node name="TileMap" type="TileMap" parent="." index="8"]
 

--- a/scenes/Door.tscn
+++ b/scenes/Door.tscn
@@ -22,6 +22,7 @@ script = ExtResource( 1 )
 _sections_unfolded = [ "Transform" ]
 KEYCARD = "None"
 SPEED = null
+DOOR_TYPE = "keycard"
 
 [node name="leftdoor" type="CollisionPolygon2D" parent="." index="0"]
 

--- a/scripts/Detection.gd
+++ b/scripts/Detection.gd
@@ -21,5 +21,5 @@ func _on_detection_body_entered(body, origin):
 			emit_signal("door_open")
 
 func _on_detection_body_exited(body, origin):
-	if body.get_name() == "Character" and door.open:
+	if body.get_name() == "Character" and door.open and door.DOOR_TYPE == 'keycard':
 		emit_signal("door_close")

--- a/scripts/door.gd
+++ b/scripts/door.gd
@@ -5,6 +5,7 @@ export(String) var KEYCARD = "None"
 var open = false
 var moving = false
 export(int) var SPEED
+export(String) var DOOR_TYPE = "keycard"
 const POS_LEFT_OPEN = Vector2(-25, 0)
 const POS_LEFT_CLOSE = Vector2(-5, 0)
 const POS_RIGHT_OPEN = Vector2(25, 0)


### PR DESCRIPTION
# master < door-bug
9:50 December 20th 2018
 - [x] Fixed doors wired to pressureplates closing when the character moves too far away from them.
 # Testing
 - [x] Tested that the fix actually fixes the problem.